### PR TITLE
README and Git URL update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Connect:
 xxh yourhost +s bash +if
 ```
 
-The default theme used is agnoster. To update set the environmental variable `OSH_THEME` to your desired theme in the XXH config filg located at `~/.config/xxh/config.xxhc`
+The default theme used is agnoster. To change the theme, set the environmental variable `OSH_THEME` to your desired theme in the XXH config file located at `~/.config/xxh/config.xxhc`
 
 Example:
 ```YAML

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ From any repo:
 xxh +I xxh-plugin-bash-ohmybash+git+https://github.com/xxh/xxh-plugin-bash-ohmybash
 ```    
 Connect:
-``````
+```
 xxh yourhost +s bash +if
+```
+
+The default theme used is agnoster. To update set the environmental variable `OSH_THEME` to your desired theme in the XXH config filg located at `~/.config/xxh/config.xxhc`
+
+Example:
+```YAML
+hosts:
+    myhost:
+        +s: bash
+        +I: 
+            - xxh-shell-bash
+            - xxh-plugin-bash-ohmybash
+        +e:    
+            - OSH_THEME="simple"
 ```

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ do
 done
 
 cd $build_dir
-url='git://github.com/ohmybash/oh-my-bash.git'
+url='https://github.com/ohmybash/oh-my-bash.git'
 home_dir=oh-my-bash
 
 [ $QUIET ] && arg_q='-q' || arg_q=''


### PR DESCRIPTION
Was getting an error cloning git repo due to using deprecated "git://". Updated to "https://" and also updated README documentation.